### PR TITLE
fix: DbConnection cannot be extended

### DIFF
--- a/edge-agent-sdk/src/androidMain/kotlin/org/hyperledger/identus/walletsdk/pluto/data/DbConnectionImpl.kt
+++ b/edge-agent-sdk/src/androidMain/kotlin/org/hyperledger/identus/walletsdk/pluto/data/DbConnectionImpl.kt
@@ -9,9 +9,9 @@ import org.hyperledger.identus.walletsdk.domain.models.PlutoError
 /**
  * DbConnection class represents a connection to the database.
  */
-actual class DbConnection actual constructor() {
-    actual var driver: SqlDriver? = null
-    actual suspend fun connectDb(context: Any?): SqlDriver {
+actual class DbConnectionImpl actual constructor() : DbConnection {
+    actual override var driver: SqlDriver? = null
+    actual override suspend fun connectDb(context: Any?): SqlDriver {
         val androidContext: Context = (context as? Context) ?: throw PlutoError.DatabaseContextError()
         val driver = AndroidSqliteDriver(SdkPlutoDb.Schema, androidContext, "prism.db")
         this.driver = driver

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/PlutoImpl.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/PlutoImpl.kt
@@ -6,6 +6,7 @@ import app.cash.sqldelight.ColumnAdapter
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.db.AfterVersion
+import java.util.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -34,10 +35,9 @@ import org.hyperledger.identus.walletsdk.domain.models.keyManagement.JWK
 import org.hyperledger.identus.walletsdk.domain.models.keyManagement.PrivateKey
 import org.hyperledger.identus.walletsdk.domain.models.keyManagement.StorableKey
 import org.hyperledger.identus.walletsdk.pluto.backup.models.BackupV0_0_1
-import org.hyperledger.identus.walletsdk.pluto.data.DbConnectionImpl
+import org.hyperledger.identus.walletsdk.pluto.data.DbConnection
 import org.hyperledger.identus.walletsdk.pluto.data.isConnected
 import org.hyperledger.identus.walletsdk.pollux.models.CredentialRequestMeta
-import java.util.UUID
 import org.hyperledger.identus.walletsdk.pluto.data.AvailableClaims as AvailableClaimsDB
 import org.hyperledger.identus.walletsdk.pluto.data.DID as DIDDB
 import org.hyperledger.identus.walletsdk.pluto.data.DIDPair as DIDPairDB
@@ -53,7 +53,7 @@ import org.hyperledger.identus.walletsdk.pluto.data.StorableCredential as Storab
  * @property db The instance of `SdkPlutoDb` representing the connection to the database.
  * @property isConnected A flag to indicate whether the database connection is established or not.
  */
-class PlutoImpl(private val connection: DbConnectionImpl) : Pluto {
+class PlutoImpl(private val connection: DbConnection) : Pluto {
     private var db: SdkPlutoDb? = null
 
     init {

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/PlutoImpl.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/PlutoImpl.kt
@@ -34,7 +34,7 @@ import org.hyperledger.identus.walletsdk.domain.models.keyManagement.JWK
 import org.hyperledger.identus.walletsdk.domain.models.keyManagement.PrivateKey
 import org.hyperledger.identus.walletsdk.domain.models.keyManagement.StorableKey
 import org.hyperledger.identus.walletsdk.pluto.backup.models.BackupV0_0_1
-import org.hyperledger.identus.walletsdk.pluto.data.DbConnection
+import org.hyperledger.identus.walletsdk.pluto.data.DbConnectionImpl
 import org.hyperledger.identus.walletsdk.pluto.data.isConnected
 import org.hyperledger.identus.walletsdk.pollux.models.CredentialRequestMeta
 import java.util.UUID
@@ -53,7 +53,7 @@ import org.hyperledger.identus.walletsdk.pluto.data.StorableCredential as Storab
  * @property db The instance of `SdkPlutoDb` representing the connection to the database.
  * @property isConnected A flag to indicate whether the database connection is established or not.
  */
-class PlutoImpl(private val connection: DbConnection) : Pluto {
+class PlutoImpl(private val connection: DbConnectionImpl) : Pluto {
     private var db: SdkPlutoDb? = null
 
     init {

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/data/DbConnectionImpl.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pluto/data/DbConnectionImpl.kt
@@ -2,11 +2,17 @@ package org.hyperledger.identus.walletsdk.pluto.data
 
 import app.cash.sqldelight.db.SqlDriver
 
+interface DbConnection {
+    var driver: SqlDriver?
+
+    suspend fun connectDb(context: Any?): SqlDriver
+}
+
 /**
  * DbConnection class represents a connection to the database.
  */
-expect class DbConnection() {
-    var driver: SqlDriver?
+expect class DbConnectionImpl() : DbConnection {
+    override var driver: SqlDriver?
 
     /**
      * Establishes a connection to the database.
@@ -15,7 +21,7 @@ expect class DbConnection() {
      *
      * @return The SdkPlutoDb instance representing the connection to the database.
      */
-    suspend fun connectDb(context: Any?): SqlDriver
+    override suspend fun connectDb(context: Any?): SqlDriver
 }
 
 /**

--- a/edge-agent-sdk/src/jvmMain/kotlin/org/hyperledger/identus/walletsdk/pluto/data/DbConnectionImpl.kt
+++ b/edge-agent-sdk/src/jvmMain/kotlin/org/hyperledger/identus/walletsdk/pluto/data/DbConnectionImpl.kt
@@ -4,9 +4,9 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import org.hyperledger.identus.walletsdk.SdkPlutoDb
 
-actual class DbConnection actual constructor() {
-    actual var driver: SqlDriver? = null
-    actual suspend fun connectDb(context: Any?): SqlDriver {
+actual class DbConnectionImpl actual constructor() : DbConnection {
+    actual override var driver: SqlDriver? = null
+    actual override suspend fun connectDb(context: Any?): SqlDriver {
         val driver = JdbcSqliteDriver("jdbc:sqlite:prism.db")
         SdkPlutoDb.Schema.create(driver)
         this.driver = driver

--- a/sampleapp/build.gradle.kts
+++ b/sampleapp/build.gradle.kts
@@ -78,6 +78,8 @@ dependencies {
     implementation("androidx.room:room-runtime:2.4.2")
     ksp("androidx.room:room-compiler:2.4.2")
 
+    implementation("app.cash.sqldelight:sqlite-driver:2.0.1")
+
     // Unit Tests
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")


### PR DESCRIPTION
Signed-off-by: Cristian G <cristian.castro@iohk.io>

### Description: 
This PR provides the DbConnection as an interface for the end to end tests to use a custom DbConnection to use in memory db.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
