### PR TITLE
refactor: change anoncreds library to aries uniffi

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,13 @@ allprojects {
         maven {
             url = uri("https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven")
         }
+        maven {
+            setUrl("https://maven.pkg.github.com/hyperledger/aries-uniffi-wrappers")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 
     configurations.all {

--- a/edge-agent-sdk/build.gradle.kts
+++ b/edge-agent-sdk/build.gradle.kts
@@ -125,7 +125,7 @@ kotlin {
 
                 api("org.lighthousegames:logging:1.1.2")
 
-                implementation("io.iohk.atala.prism.anoncredskmp:anoncreds-kmp:0.4.6")
+                implementation("org.hyperledger:anoncreds_uniffi:0.2.0-wrapper.1")
                 implementation("com.ionspin.kotlin:bignum:0.3.9")
                 implementation("org.bouncycastle:bcprov-jdk15on:1.68")
                 implementation("eu.europa.ec.eudi:eudi-lib-jvm-sdjwt-kt:0.4.0") {

--- a/edge-agent-sdk/src/androidInstrumentedTest/kotlin/org/hyperledger/identus/walletsdk/edgeagent/AnoncredsTests.kt
+++ b/edge-agent-sdk/src/androidInstrumentedTest/kotlin/org/hyperledger/identus/walletsdk/edgeagent/AnoncredsTests.kt
@@ -3,7 +3,7 @@
 package org.hyperledger.identus.walletsdk.edgeagent
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import anoncreds_wrapper.LinkSecret
+import anoncreds_uniffi.LinkSecret
 import org.hyperledger.identus.apollo.base64.base64UrlDecoded
 import org.hyperledger.identus.apollo.derivation.MnemonicHelper
 import io.ktor.http.HttpHeaders

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/domain/buildingblocks/Pollux.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/domain/buildingblocks/Pollux.kt
@@ -1,9 +1,9 @@
 package org.hyperledger.identus.walletsdk.domain.buildingblocks
 
-import anoncreds_wrapper.CredentialOffer
-import anoncreds_wrapper.CredentialRequest
-import anoncreds_wrapper.CredentialRequestMetadata
-import anoncreds_wrapper.LinkSecret
+// TODO: This domain interfaces cannot have dependencies to outside of domain classes
+import anoncreds_uniffi.CredentialOffer
+import anoncreds_uniffi.CredentialRequest
+import anoncreds_uniffi.CredentialRequestMetadata
 import kotlinx.serialization.json.JsonObject
 import org.hyperledger.identus.walletsdk.domain.models.AttachmentDescriptor
 import org.hyperledger.identus.walletsdk.domain.models.Credential
@@ -34,7 +34,7 @@ interface Pollux {
     suspend fun parseCredential(
         jsonData: String,
         type: CredentialType,
-        linkSecret: LinkSecret? = null,
+        linkSecret: String? = null,
         credentialMetadata: CredentialRequestMetadata?
     ): Credential
 
@@ -78,7 +78,7 @@ interface Pollux {
     suspend fun processCredentialRequestAnoncreds(
         did: DID,
         offer: CredentialOffer,
-        linkSecret: LinkSecret,
+        linkSecret: String,
         linkSecretName: String
     ): Pair<CredentialRequest, CredentialRequestMetadata>
 

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgent.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgent.kt
@@ -2,9 +2,9 @@
 
 package org.hyperledger.identus.walletsdk.edgeagent
 
-import anoncreds_wrapper.CredentialOffer
-import anoncreds_wrapper.CredentialRequestMetadata
-import anoncreds_wrapper.LinkSecret
+import anoncreds_uniffi.CredentialOffer
+import anoncreds_uniffi.CredentialRequestMetadata
+import anoncreds_uniffi.createLinkSecret
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.JWEDecrypter
@@ -693,7 +693,7 @@ open class EdgeAgent {
                 val credentialRequest = pair.first
                 val credentialRequestMetadata = pair.second
 
-                val json = credentialRequest.getJson()
+                val json = credentialRequest.toJson()
 
                 val metadata =
                     CredentialRequestMeta.fromCredentialRequestMetadata(credentialRequestMetadata)
@@ -984,7 +984,7 @@ open class EdgeAgent {
                 presentationString = credential.presentation(
                     requestData.encodeToByteArray(),
                     listOf(
-                        CredentialOperationsOptions.LinkSecret("", linkSecret.getValue()),
+                        CredentialOperationsOptions.LinkSecret("", linkSecret),
                         CredentialOperationsOptions.SchemaDownloader(api),
                         CredentialOperationsOptions.CredentialDefinitionDownloader(api)
                     )
@@ -1298,14 +1298,14 @@ open class EdgeAgent {
      *
      * @return The retrieved or newly created link secret object.
      */
-    private suspend fun getLinkSecret(): LinkSecret {
+    private suspend fun getLinkSecret(): String {
         val linkSecret = pluto.getLinkSecret().firstOrNull()
         return if (linkSecret == null) {
-            val linkSecretObj = LinkSecret()
-            pluto.storeLinkSecret(linkSecretObj.getValue())
+            val linkSecretObj = createLinkSecret()
+            pluto.storeLinkSecret(linkSecretObj)
             linkSecretObj
         } else {
-            LinkSecret.newFromValue(linkSecret)
+            linkSecret
         }
     }
 

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pollux/models/AnonCredential.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pollux/models/AnonCredential.kt
@@ -1,15 +1,9 @@
 package org.hyperledger.identus.walletsdk.pollux.models
 
-import anoncreds_wrapper.CredentialDefinition
-import anoncreds_wrapper.CredentialDefinitionId
-import anoncreds_wrapper.CredentialRequests
-import anoncreds_wrapper.LinkSecret
-import anoncreds_wrapper.PresentationRequest
-import anoncreds_wrapper.Prover
-import anoncreds_wrapper.RequestedAttribute
-import anoncreds_wrapper.RequestedPredicate
-import anoncreds_wrapper.Schema
-import anoncreds_wrapper.SchemaId
+import anoncreds_uniffi.CredentialDefinition
+import anoncreds_uniffi.PresentationRequest
+import anoncreds_uniffi.Prover
+import anoncreds_uniffi.Schema
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -17,9 +11,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNames
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.didcommx.didcomm.common.Typ
 import org.hyperledger.identus.walletsdk.domain.models.Api
@@ -171,42 +167,41 @@ data class AnonCredential(
         }
 
         val presentationRequest = PresentationRequest(request.toString())
-        val cred = anoncreds_wrapper.Credential(this.id)
+        val cred = anoncreds_uniffi.Credential(this.id)
 
-        val requestedAttributes =
-            presentationRequest.getRequestedAttributes().toListRequestedAttribute()
-        val requestedPredicate =
-            presentationRequest.getRequestedPredicates().toListRequestedPredicate()
+        val requestedAttributes = extractRequestedAttributes(request.toString())
+        val requestedPredicates = extractRequestedPredicatesKeys(request.toString())
 
-        val credentialRequests = CredentialRequests(
-            credential = cred,
-            requestedAttribute = requestedAttributes,
-            requestedPredicate = requestedPredicate
+        val credentialRequests = anoncreds_uniffi.RequestedCredential(
+            cred = cred,
+            timestamp = null,
+            revState = null,
+            requestedAttributes = requestedAttributes,
+            requestedPredicates = requestedPredicates
         )
         val schemaId = this.schemaID
         // When testing using a local instance of an agent, we need to replace the host.docker.internal with the local IP
         // .replace("host.docker.internal", "192.168.68.114")
         val schema = getSchema(schemaId, schemaDownloader)
 
-        val schemaMap: Map<SchemaId, Schema> = mapOf(Pair(this.schemaID, schema))
+        val schemaMap: Map<String, Schema> = mapOf(Pair(this.schemaID, schema))
 
         val credDefId = this.credentialDefinitionID
         // When testing using a local instance of an agent, we need to replace the host.docker.internal with the local IP
         // .replace("host.docker.internal", "192.168.68.114")
         val credentialDefinition = getCredentialDefinition(credDefId, definitionDownloader)
-        val credDefinition: Map<CredentialDefinitionId, CredentialDefinition> = mapOf(
+        val credDefinition: Map<String, CredentialDefinition> = mapOf(
             Pair(this.credentialDefinitionID, credentialDefinition)
         )
-        val linkSecretAnon = LinkSecret.newFromValue(linkSecret)
 
         return Prover().createPresentation(
-            presentationRequest = presentationRequest,
-            credentials = listOf(credentialRequests),
-            selfAttested = null,
-            linkSecret = linkSecretAnon,
+            presReq = presentationRequest,
+            requestedCredentials = listOf(credentialRequests),
+            selfAttestedAttributes = null,
+            linkSecret = linkSecret,
             schemas = schemaMap,
-            credentialDefinitions = credDefinition
-        ).getJson()
+            credDefs = credDefinition
+        ).toJson()
     }
 
     /**
@@ -267,29 +262,32 @@ data class AnonCredential(
     }
 
     /**
-     * Converts the map of [anoncreds_wrapper.AttributeInfoValue] values to a list of [RequestedAttribute].
+     * Converts the map of [anoncreds_uniffi.AttributeInfoValue] values to a list of [RequestedAttribute].
      *
      * @return The list of [RequestedAttribute].
      */
-    private fun Map<String, anoncreds_wrapper.AttributeInfoValue>.toListRequestedAttribute(): List<RequestedAttribute> {
-        return this.keys.toList().map {
-            RequestedAttribute(
-                referent = it,
-                revealed = true
-            )
-        }
+    private fun extractRequestedAttributes(jsonString: String): Map<String, Boolean> {
+        val jsonElement: JsonElement = Json.parseToJsonElement(jsonString)
+        val jsonObject: JsonObject = jsonElement.jsonObject
+        val requestedAttributes = jsonObject["requested_attributes"]?.jsonObject ?: JsonObject(mapOf())
+        val resultMap = requestedAttributes.keys.associateWith { true }
+
+        return resultMap
     }
 
     /**
-     * Converts the map of [anoncreds_wrapper.PredicateInfoValue] values to a list of [RequestedPredicate].
+     * Converts the map of [anoncreds_uniffi.PredicateInfoValue] values to a list of [RequestedPredicate].
      *
-     * @receiver The map of [anoncreds_wrapper.PredicateInfoValue] values.
+     * @receiver The map of [anoncreds_uniffi.PredicateInfoValue] values.
      * @return The list of [RequestedPredicate].
      */
-    private fun Map<String, anoncreds_wrapper.PredicateInfoValue>.toListRequestedPredicate(): List<RequestedPredicate> {
-        return this.keys.toList().map {
-            RequestedPredicate(it)
-        }
+    private fun extractRequestedPredicatesKeys(jsonString: String): List<String> {
+        val jsonElement: JsonElement = Json.parseToJsonElement(jsonString)
+        val jsonObject: JsonObject = jsonElement.jsonObject
+        val requestedPredicates = jsonObject["requested_predicates"]?.jsonObject ?: JsonObject(mapOf())
+        val keysList = requestedPredicates.keys.toList()
+
+        return keysList
     }
 
     /**
@@ -330,12 +328,10 @@ data class AnonCredential(
                 val attrNames = attrs?.jsonArray?.map { value -> value.jsonPrimitive.content }
                 val issuerId =
                     schema["issuerId"]?.jsonPrimitive?.content
-                return Schema(
-                    name = name ?: throw PolluxError.InvalidCredentialError(),
-                    version = version ?: throw PolluxError.InvalidCredentialError(),
-                    attrNames = attrNames ?: throw PolluxError.InvalidCredentialError(),
-                    issuerId = issuerId ?: throw PolluxError.InvalidCredentialError()
-                )
+                if (name == null || version == null || attrNames == null || issuerId == null) {
+                    throw PolluxError.InvalidCredentialError()
+                }
+                return Schema(result.jsonString)
             }
         }
         throw PolluxError.InvalidCredentialDefinitionError()

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pollux/models/CredentialRequestMeta.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pollux/models/CredentialRequestMeta.kt
@@ -1,6 +1,8 @@
 package org.hyperledger.identus.walletsdk.pollux.models
 
-import anoncreds_wrapper.CredentialRequestMetadata
+import anoncreds_uniffi.CredentialRequestMetadata
+import io.iohk.atala.prism.didcomm.didpeer.core.toJsonElement
+import kotlinx.serialization.json.jsonObject
 
 /**
  * Represents the metadata for a credential request.
@@ -22,8 +24,8 @@ data class CredentialRequestMeta(
         @JvmStatic
         fun fromCredentialRequestMetadata(metadata: CredentialRequestMetadata): CredentialRequestMeta {
             return CredentialRequestMeta(
-                linkSecretName = metadata.getLinkSecretName().replace("\"", ""),
-                json = metadata.getJson()
+                linkSecretName = metadata.toJsonElement().jsonObject["link_secret_name"]?.toString()?.replace("\"", "") ?: "",
+                json = metadata.toJson()
             )
         }
     }

--- a/edge-agent-sdk/src/commonTest/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgentTests.kt
+++ b/edge-agent-sdk/src/commonTest/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgentTests.kt
@@ -2,7 +2,7 @@
 
 package org.hyperledger.identus.walletsdk.edgeagent
 
-import anoncreds_wrapper.LinkSecret
+import anoncreds_uniffi.createLinkSecret
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.JWEObject
@@ -942,7 +942,7 @@ class EdgeAgentTests {
             getCredentialDefinitionResponse
         )
         val pollux = PolluxImpl(apolloMockOld, castorMockOld, apiMock)
-        plutoMockOld.getLinkSecretReturn = flow { emit(LinkSecret().getValue()) }
+        plutoMockOld.getLinkSecretReturn = flow { emit(createLinkSecret()) }
         val meta = CredentialRequestMeta(
             linkSecretName = "1",
             json = "{\"link_secret_blinding_data\":{\"v_prime\":\"1234\",\"vr_prime\":\"1234\"},\"nonce\":\"411729288962137159046778\",\"link_secret_name\":\"link:secret:id\"}"

--- a/edge-agent-sdk/src/commonTest/kotlin/org/hyperledger/identus/walletsdk/edgeagent/PolluxMock.kt
+++ b/edge-agent-sdk/src/commonTest/kotlin/org/hyperledger/identus/walletsdk/edgeagent/PolluxMock.kt
@@ -1,8 +1,7 @@
 package org.hyperledger.identus.walletsdk.edgeagent
 
-import anoncreds_wrapper.CredentialOffer
-import anoncreds_wrapper.CredentialRequestMetadata
-import anoncreds_wrapper.LinkSecret
+import anoncreds_uniffi.CredentialOffer
+import anoncreds_uniffi.CredentialRequestMetadata
 import kotlinx.serialization.json.JsonObject
 import org.hyperledger.identus.walletsdk.domain.buildingblocks.Pollux
 import org.hyperledger.identus.walletsdk.domain.models.AttachmentDescriptor
@@ -27,7 +26,7 @@ class PolluxMock : Pollux {
     override suspend fun parseCredential(
         jsonData: String,
         type: CredentialType,
-        linkSecret: LinkSecret?,
+        linkSecret: String?,
         credentialMetadata: CredentialRequestMetadata?
     ): Credential {
         TODO("Not yet implemented")
@@ -52,9 +51,9 @@ class PolluxMock : Pollux {
     override suspend fun processCredentialRequestAnoncreds(
         did: DID,
         offer: CredentialOffer,
-        linkSecret: LinkSecret,
+        linkSecret: String,
         linkSecretName: String
-    ): Pair<anoncreds_wrapper.CredentialRequest, CredentialRequestMetadata> {
+    ): Pair<anoncreds_uniffi.CredentialRequest, CredentialRequestMetadata> {
         TODO("Not yet implemented")
         // return processCredentialRequestAnoncredsReturn ?: throw Exception("Return not defined")
     }


### PR DESCRIPTION
### Description: 
We are changing from our rust uniffi [anoncreds library](https://github.com/input-output-hk/anoncreds-rs) to the Aries uniffi [anoncreds library](https://github.com/hyperledger/aries-uniffi-wrappers)

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
