### PR TITLE
feat: contactless presentation request

### DIFF
--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/domain/models/Errors.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/domain/models/Errors.kt
@@ -691,7 +691,7 @@ constructor(
     /**
      * Represents an error that occurs when a field is null but should not be.
      */
-    class NonNullableError(val field: String) : PolluxError("Field $field are non nullable.") {
+    class NonNullableError(val field: String) : PolluxError("Field $field is non nullable.") {
         override val code: Int
             get() = 516
     }

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/domain/models/MessageAttachment.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/domain/models/MessageAttachment.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
@@ -319,6 +320,10 @@ object AttachmentDataSerializer : KSerializer<AttachmentData> {
 
             json.containsKey("data") -> {
                 jsonSerializable.decodeFromJsonElement(AttachmentData.AttachmentJsonData.serializer(), json)
+            }
+
+            json.containsKey("json") -> {
+                AttachmentData.AttachmentJsonData(data = Json.encodeToString(json["json"]!!.jsonObject))
             }
 
             else -> throw SerializationException("Unknown AttachmentData type")

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgent.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgent.kt
@@ -36,8 +36,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
-import kotlinx.datetime.isDistantFuture
-import kotlinx.datetime.isDistantPast
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgentError.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgentError.kt
@@ -143,4 +143,13 @@ sealed class EdgeAgentError : KnownPrismError() {
         override val message: String
             get() = "This credential does not fulfill the criteria required by the request."
     }
+
+    class ExpiredInvitation() :
+        EdgeAgentError() {
+        override val code: Int
+            get() = 615
+
+        override val message: String
+            get() = "This invitation has expired."
+    }
 }

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/outOfBand/OutOfBandInvitation.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/outOfBand/OutOfBandInvitation.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.hyperledger.identus.walletsdk.domain.models.AttachmentDescriptor
 import org.hyperledger.identus.walletsdk.edgeagent.GOAL_CODE
 import org.hyperledger.identus.walletsdk.edgeagent.protocols.ProtocolType
 import java.util.UUID
@@ -23,7 +24,12 @@ constructor(
     @EncodeDefault
     val type: ProtocolType = ProtocolType.Didcomminvitation,
     @EncodeDefault
-    val typ: String? = null
+    val typ: String? = null,
+    val attachments: Array<AttachmentDescriptor> = arrayOf(),
+    @SerialName("created_time")
+    val createdTime: Long = 0,
+    @SerialName("expires_time")
+    val expiresTime: Long = 0
 ) : InvitationType() {
 
     /**

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/Presentation.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/Presentation.kt
@@ -189,20 +189,20 @@ class Presentation {
      * @return The converted Presentation object.
      * @throws EdgeAgentError.InvalidMessageType If the message type is invalid.
      */
-    @Throws(EdgeAgentError.InvalidMessageType::class)
-    fun makePresentationFromRequest(msg: Message): Presentation {
-        val requestPresentation = RequestPresentation.fromMessage(msg)
-        return Presentation(
-            body = Body(
-                goalCode = requestPresentation.body.goalCode,
-                comment = requestPresentation.body.comment
-            ),
-            attachments = requestPresentation.attachments,
-            thid = requestPresentation.id,
-            from = requestPresentation.to,
-            to = requestPresentation.from
-        )
-    }
+//    @Throws(EdgeAgentError.InvalidMessageType::class)
+//    fun makePresentationFromRequest(msg: Message): Presentation {
+//        val requestPresentation = RequestPresentation.fromMessage(msg)
+//        return Presentation(
+//            body = Body(
+//                goalCode = requestPresentation.body.goalCode,
+//                comment = requestPresentation.body.comment
+//            ),
+//            attachments = requestPresentation.attachments,
+//            thid = requestPresentation.id,
+//            from = requestPresentation.to,
+//            to = requestPresentation.from
+//        )
+//    }
 
     /**
      * Compares this Presentation object with the specified object for equality.

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/Presentation.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/Presentation.kt
@@ -183,28 +183,6 @@ class Presentation {
     }
 
     /**
-     * Converts a message into a Presentation object.
-     *
-     * @param msg The input message to convert.
-     * @return The converted Presentation object.
-     * @throws EdgeAgentError.InvalidMessageType If the message type is invalid.
-     */
-//    @Throws(EdgeAgentError.InvalidMessageType::class)
-//    fun makePresentationFromRequest(msg: Message): Presentation {
-//        val requestPresentation = RequestPresentation.fromMessage(msg)
-//        return Presentation(
-//            body = Body(
-//                goalCode = requestPresentation.body.goalCode,
-//                comment = requestPresentation.body.comment
-//            ),
-//            attachments = requestPresentation.attachments,
-//            thid = requestPresentation.id,
-//            from = requestPresentation.to,
-//            to = requestPresentation.from
-//        )
-//    }
-
-    /**
      * Compares this Presentation object with the specified object for equality.
      *
      * @param other The object to compare with this Presentation object.

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/ProposePresentation.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/ProposePresentation.kt
@@ -114,30 +114,6 @@ class ProposePresentation {
     }
 
     /**
-     * Creates a proposal presentation from a request message.
-     *
-     * @param msg The request message.
-     * @return The created `ProposePresentation` object.
-     * @throws EdgeAgentError.InvalidMessageType If the message type does not represent the expected protocol.
-     */
-//    @Throws(EdgeAgentError.InvalidMessageType::class)
-//    fun makeProposalFromRequest(msg: Message): ProposePresentation {
-//        val request = RequestPresentation.fromMessage(msg)
-//
-//        return ProposePresentation(
-//            body = Body(
-//                goalCode = request.body.goalCode,
-//                comment = request.body.comment,
-//                proofTypes = request.body.proofTypes
-//            ),
-//            attachments = request.attachments,
-//            thid = msg.id,
-//            from = request.to,
-//            to = request.from
-//        )
-//    }
-
-    /**
      * Compares this object with the specified object for equality.
      *
      * @param other the object to compare for equality.

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/ProposePresentation.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/ProposePresentation.kt
@@ -120,22 +120,22 @@ class ProposePresentation {
      * @return The created `ProposePresentation` object.
      * @throws EdgeAgentError.InvalidMessageType If the message type does not represent the expected protocol.
      */
-    @Throws(EdgeAgentError.InvalidMessageType::class)
-    fun makeProposalFromRequest(msg: Message): ProposePresentation {
-        val request = RequestPresentation.fromMessage(msg)
-
-        return ProposePresentation(
-            body = Body(
-                goalCode = request.body.goalCode,
-                comment = request.body.comment,
-                proofTypes = request.body.proofTypes
-            ),
-            attachments = request.attachments,
-            thid = msg.id,
-            from = request.to,
-            to = request.from
-        )
-    }
+//    @Throws(EdgeAgentError.InvalidMessageType::class)
+//    fun makeProposalFromRequest(msg: Message): ProposePresentation {
+//        val request = RequestPresentation.fromMessage(msg)
+//
+//        return ProposePresentation(
+//            body = Body(
+//                goalCode = request.body.goalCode,
+//                comment = request.body.comment,
+//                proofTypes = request.body.proofTypes
+//            ),
+//            attachments = request.attachments,
+//            thid = msg.id,
+//            from = request.to,
+//            to = request.from
+//        )
+//    }
 
     /**
      * Compares this object with the specified object for equality.

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/RequestPresentation.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/proofOfPresentation/RequestPresentation.kt
@@ -33,7 +33,7 @@ data class RequestPresentation(
     val attachments: Array<AttachmentDescriptor>,
     val thid: String? = null,
     val from: DID,
-    val to: DID,
+    val to: DID? = null,
     val direction: Message.Direction = Message.Direction.RECEIVED
 ) {
 

--- a/sampleapp/src/main/java/org/hyperledger/identus/walletsdk/sampleapp/ui/contacts/ContactsViewModel.kt
+++ b/sampleapp/src/main/java/org/hyperledger/identus/walletsdk/sampleapp/ui/contacts/ContactsViewModel.kt
@@ -36,18 +36,22 @@ class ContactsViewModel(application: Application) : AndroidViewModel(application
     fun parseAndAcceptOOB(oobUrl: String) {
         Sdk.getInstance().agent.let { agent ->
             viewModelScope.launch {
-                when (val invitation = agent.parseInvitation(oobUrl)) {
-                    is OutOfBandInvitation -> {
-                        agent.acceptOutOfBandInvitation(invitation)
-                    }
+                try {
+                    when (val invitation = agent.parseInvitation(oobUrl)) {
+                        is OutOfBandInvitation -> {
+                            agent.acceptOutOfBandInvitation(invitation)
+                        }
 
-                    is PrismOnboardingInvitation -> {
-                        agent.acceptInvitation(invitation)
-                    }
+                        is PrismOnboardingInvitation -> {
+                            agent.acceptInvitation(invitation)
+                        }
 
-                    else -> {
-                        throw EdgeAgentError.UnknownInvitationTypeError(invitation.toString())
+                        else -> {
+                            throw EdgeAgentError.UnknownInvitationTypeError(invitation.toString())
+                        }
                     }
+                } catch (e: Exception) {
+                    println("Exception: ${e.message}")
                 }
             }
         }

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="mediator_did">Mediator DID:</string>
     <string name="agent_status_label">Agent status:</string>
     <string name="mediator_did_value">
-        did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly8xOTIuMTY4LjY4LjExMzo4MDgwIiwiYSI6WyJkaWRjb21tL3YyIl19fQ
+        did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly8xOTIuMTY4LjY4LjExMzo4MDgwIiwiYSI6WyJkaWRjb21tL3YyIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6IndzOi8vMTkyLjE2OC42OC4xMTM6ODA4MC93cyIsImEiOlsiZGlkY29tbS92MiJdfX0
     </string>
     <string name="credentials_label">Credentials</string>
     <string name="host_label">Host:</string>


### PR DESCRIPTION
### Description: 
This PR brings contactless presentation request to the kmm SDK.
The OOB is taken as usual but when it contains a presentation request it takes a different route to verify is not expired, verifies all required fields are there and stores the request presentation so the user can display the request to the end user.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
