### PR TITLE
fix: anoncred verification and breaking changes missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The complete platform is separated into multiple repositories:
 * [edge-agent-sdk-swift](https://github.com/hyperledger/identus-edge-agent-sdk-swift/) - Repo that implements Edge Agent for Apple platforms in Swift.
 * [edge-agent-sdk-ts](https://github.com/hyperledger/identus-edge-agent-sdk-ts/) - Repo that implements Edge Agent for Browser and Node.js platforms in Typescript.
 * [identus-cloud-agent](https://github.com/hyperledger/identus-cloud-agent/) - Repo that contains the platform Building Blocks.
-* [mediator](https://github.com/hyperledger/identus-mediator/) - Repo for DIDComm V2 Mediator
+* [mediator](https://github.com/hyperledger/identus-mediator/) - Repo for DIDComm V2 Mediator.
 
 ### Modules / APIs
 

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgent.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgent.kt
@@ -654,10 +654,7 @@ open class EdgeAgent {
                     KeyCurve(Curve.SECP256K1, privateKeyKeyPath)
                 )
                 val offerDataString = offer.attachments.firstNotNullOf {
-                    when (it.data) {
-                        is AttachmentJsonData -> it.data.data
-                        else -> null
-                    }
+                    it.data.getDataAsJsonString()
                 }
                 val offerJsonObject = Json.parseToJsonElement(offerDataString).jsonObject
                 val jwtString =
@@ -1057,12 +1054,9 @@ open class EdgeAgent {
                 if (format != CredentialType.ANONCREDS_PROOF_REQUEST) {
                     throw EdgeAgentError.InvalidCredentialFormatError(CredentialType.ANONCREDS_PROOF_REQUEST)
                 }
-                val requestData = request.attachments.mapNotNull {
-                    when (it.data) {
-                        is AttachmentJsonData -> it.data.data
-                        else -> null
-                    }
-                }.first()
+                val requestData = request.attachments.firstNotNullOf {
+                    it.data.getDataAsJsonString()
+                }
                 val linkSecret = getLinkSecret()
                 try {
                     presentationString = credential.presentation(
@@ -1093,10 +1087,7 @@ open class EdgeAgent {
                         KeyCurve(Curve.SECP256K1, privateKeyKeyPath)
                     )
                 val requestData = request.attachments.firstNotNullOf {
-                    when (it.data) {
-                        is AttachmentJsonData -> it.data.data
-                        else -> null
-                    }
+                    it.data.getDataAsJsonString()
                 }
                 try {
                     presentationString = credential.presentation(
@@ -1113,15 +1104,12 @@ open class EdgeAgent {
             }
 
             CredentialType.SDJWT.type -> {
-                val requestData = request.attachments.mapNotNull {
-                    when (it.data) {
-                        is AttachmentJsonData -> it.data.data
-                        else -> null
-                    }
-                }.first().encodeToByteArray()
+                val requestData = request.attachments.firstNotNullOf {
+                    it.data.getDataAsJsonString()
+                }
                 try {
                     presentationString = credential.presentation(
-                        requestData,
+                        requestData.encodeToByteArray(),
                         listOf(CredentialOperationsOptions.DisclosingClaims(listOf(credential.claims.toString())))
                     )
                 } catch (e: Exception) {
@@ -1194,7 +1182,7 @@ open class EdgeAgent {
                     type = type,
                     presentationClaims = presentationClaims,
                     options = AnoncredsPresentationOptions(
-                        nonce = generateNonce()
+                        nonce = generateNumericNonce()
                     )
                 )
                 attachmentDescriptor = AttachmentDescriptor(
@@ -1244,10 +1232,13 @@ open class EdgeAgent {
                     ?: throw EdgeAgentError.CannotFindDIDPrivateKey(didString)
                 val privateKey =
                     apollo.restorePrivateKey(storablePrivateKey.restorationIdentifier, storablePrivateKey.data)
-                val presentationSubmissionProof = pollux.createJWTPresentationSubmission(
-                    presentationDefinitionRequest = presentationDefinitionRequestString,
-                    credential = credential,
-                    privateKey = privateKey,
+
+                val presentationSubmissionProof = credential.presentation(
+                    presentationDefinitionRequestString.encodeToByteArray(),
+                    listOf(
+                        CredentialOperationsOptions.SubjectDID(DID(didString)),
+                        CredentialOperationsOptions.ExportableKey(privateKey)
+                    )
                 )
 
                 val attachmentDescriptor = AttachmentDescriptor(
@@ -1266,10 +1257,14 @@ open class EdgeAgent {
                 )
             } else {
                 val linkSecret = getLinkSecret()
-                val presentationSubmissionProof = pollux.createAnoncredsPresentationSubmission(
-                    presentationDefinitionRequest = presentationDefinitionRequestString,
-                    credential = credential,
-                    linkSecret = linkSecret
+
+                val presentationSubmissionProof = credential.presentation(
+                    presentationDefinitionRequestString.encodeToByteArray(),
+                    listOf(
+                        CredentialOperationsOptions.LinkSecret("", linkSecret),
+                        CredentialOperationsOptions.SchemaDownloader(api),
+                        CredentialOperationsOptions.CredentialDefinitionDownloader(api)
+                    )
                 )
 
                 val attachmentDescriptor = AttachmentDescriptor(
@@ -1490,11 +1485,16 @@ open class EdgeAgent {
         }
     }
 
-    private fun generateNonce(size: Int = 16): String {
+    private fun generateNumericNonce(size: Int = 16): String {
         val random = SecureRandom()
-        val nonce = ByteArray(size)
-        random.nextBytes(nonce)
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(nonce)
+        val nonce = StringBuilder(size)
+
+        repeat(size) {
+            val digit = random.nextInt(10) // Generates a number between 0 and 9
+            nonce.append(digit)
+        }
+
+        return nonce.toString()
     }
 
     /**

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgent.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/EdgeAgent.kt
@@ -1233,12 +1233,10 @@ open class EdgeAgent {
                 val privateKey =
                     apollo.restorePrivateKey(storablePrivateKey.restorationIdentifier, storablePrivateKey.data)
 
-                val presentationSubmissionProof = credential.presentation(
-                    presentationDefinitionRequestString.encodeToByteArray(),
-                    listOf(
-                        CredentialOperationsOptions.SubjectDID(DID(didString)),
-                        CredentialOperationsOptions.ExportableKey(privateKey)
-                    )
+                val presentationSubmissionProof = pollux.createJWTPresentationSubmission(
+                    presentationDefinitionRequest = presentationDefinitionRequestString,
+                    credential = credential,
+                    privateKey = privateKey,
                 )
 
                 val attachmentDescriptor = AttachmentDescriptor(
@@ -1258,13 +1256,10 @@ open class EdgeAgent {
             } else {
                 val linkSecret = getLinkSecret()
 
-                val presentationSubmissionProof = credential.presentation(
-                    presentationDefinitionRequestString.encodeToByteArray(),
-                    listOf(
-                        CredentialOperationsOptions.LinkSecret("", linkSecret),
-                        CredentialOperationsOptions.SchemaDownloader(api),
-                        CredentialOperationsOptions.CredentialDefinitionDownloader(api)
-                    )
+                val presentationSubmissionProof = pollux.createAnoncredsPresentationSubmission(
+                    presentationDefinitionRequest = presentationDefinitionRequestString,
+                    credential = credential,
+                    linkSecret = linkSecret
                 )
 
                 val attachmentDescriptor = AttachmentDescriptor(

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/mediation/BasicMediatorHandler.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/mediation/BasicMediatorHandler.kt
@@ -155,12 +155,7 @@ class BasicMediatorHandler(
         return flow {
             val message = mercury.sendMessageParseResponse(requestMessage)
             message?.let {
-                try {
-                    emit(PickupRunner(message, mercury).run())
-                } catch (e: Exception) {
-                    println("Message of type ${message.piuri} cannot be sent to PickupRunner")
-                    e.printStackTrace()
-                }
+                emit(PickupRunner(message, mercury).run())
             }
         }
     }

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/pickup/PickupRunner.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/edgeagent/protocols/pickup/PickupRunner.kt
@@ -1,9 +1,6 @@
 package org.hyperledger.identus.walletsdk.edgeagent.protocols.pickup
 
-import org.hyperledger.identus.apollo.base64.base64UrlDecoded
 import org.hyperledger.identus.walletsdk.domain.buildingblocks.Mercury
-import org.hyperledger.identus.walletsdk.domain.models.AttachmentData.AttachmentBase64
-import org.hyperledger.identus.walletsdk.domain.models.AttachmentData.AttachmentJsonData
 import org.hyperledger.identus.walletsdk.domain.models.AttachmentDescriptor
 import org.hyperledger.identus.walletsdk.domain.models.Message
 import org.hyperledger.identus.walletsdk.edgeagent.EdgeAgentError
@@ -97,22 +94,12 @@ class PickupRunner(message: Message, private val mercury: Mercury) {
      * @return The PickupAttachment object if the attachment data is of type AttachmentBase64 or AttachmentJsonData, otherwise null.
      */
     private fun processAttachment(attachment: AttachmentDescriptor): PickupAttachment? {
-        return when (attachment.data) {
-            is AttachmentBase64 -> {
-                PickupAttachment(
-                    attachmentId = attachment.id,
-                    data = attachment.data.base64.base64UrlDecoded
-                )
-            }
+        val data = attachment.data.getDataAsJsonString()
+        val id = attachment.id
 
-            is AttachmentJsonData -> {
-                PickupAttachment(
-                    attachmentId = attachment.id,
-                    data = attachment.data.data
-                )
-            }
-
-            else -> null
-        }
+        return PickupAttachment(
+            attachmentId = id,
+            data = data
+        )
     }
 }

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pollux/models/AnonCredential.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pollux/models/AnonCredential.kt
@@ -166,11 +166,12 @@ data class AnonCredential(
             throw UnknownError.SomethingWentWrongError()
         }
 
-        val presentationRequest = PresentationRequest(request.decodeToString())
+        val decodedRequest = request.decodeToString()
+        val presentationRequest = PresentationRequest(decodedRequest)
         val cred = anoncreds_uniffi.Credential(this.id)
 
-        val requestedAttributes = extractRequestedAttributes(request.toString())
-        val requestedPredicates = extractRequestedPredicatesKeys(request.toString())
+        val requestedAttributes = extractRequestedAttributes(decodedRequest)
+        val requestedPredicates = extractRequestedPredicatesKeys(decodedRequest)
 
         val credentialRequests = anoncreds_uniffi.RequestedCredential(
             cred = cred,

--- a/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pollux/models/AnonCredential.kt
+++ b/edge-agent-sdk/src/commonMain/kotlin/org/hyperledger/identus/walletsdk/pollux/models/AnonCredential.kt
@@ -166,7 +166,7 @@ data class AnonCredential(
             throw UnknownError.SomethingWentWrongError()
         }
 
-        val presentationRequest = PresentationRequest(request.toString())
+        val presentationRequest = PresentationRequest(request.decodeToString())
         val cred = anoncreds_uniffi.Credential(this.id)
 
         val requestedAttributes = extractRequestedAttributes(request.toString())


### PR DESCRIPTION
### Description: 
This PR remediates the lack of commits with breaking changes messages. We noticed no commit with breaking change contains that as part of the PR message leading to the semantic release not being able to bump the version accordingly.
Also used the PR to add a fix to en issue found by QA on the anoncred verification flow.

BREAKING CHANGE:

Pollux Module
- `restoreCredential` now requires a third parameter `revoked`.
- Removed: `createVerifiablePresentationJWT`, `createVerifiablePresentationAnoncred`, `getCredentialDefinition`, and `getSchema`.
- Added new method: `processCredentialRequestSDJWT`.
- `PolluxImpl` now implements `processCredentialRequestSDJWT`.
- Pollux methods `parseCredential` and `processCredentialRequestAnoncreds` now accept `linkSecret: String` instead of `linkSecret: LinkSecret`.

ConnectionManager
- `ConnectionManager` is now an interface, and `ConnectionManagerImpl` is the new implementation.
- `ConnectionManager` construct now requires a Pollux instance.

Edge Agent (formerly PrismAgent)
- The constructor now requires a new parameter: `AgentOptions`.
- `PrismAgent` renamed to `EdgeAgent`.
- `preparePresentationForRequestProof` now expects a `Credential` of type T, where T can be `Credential` or `ProvableCredential`.

JWT Verifiable Credential
- The `JWTVerifiableCredential` constructor replaces the parameter `credentialStatus: VerifiableCredentialTypeContainer` with `credentialStatus: CredentialStatus`.

Pluto Module
- `getDIDPrivateKeysByDID` and `getDIDPrivateKeyByID` now return `Flow<List<StorablePrivateKey?>>`.
- New method added: `getAllPrivateKeys`.
- `PlutoImpl` deprecated `storeCredentialMetadata(name: String, metadata: CredentialRequestMeta)` and replaced it with `storeCredentialMetadata(name: String, linkSecretName: String, json: String)`.

Apollo Module
- `restorePrivateKey(storablePrivateKey: StorablePrivateKey): PrivateKey` changed to `restorePrivateKey(restorationIdentifier: String, privateKeyData: String): PrivateKey`.

DbConnection
- `DbConnection` is now an interface.
- `DbConnectionImpl` is the new instance used for DB connections.

Presentation Submissions
- `createPresentationSubmission` parameter `presentationDefinitionRequest: PresentationDefinitionRequest` changed to `presentationDefinitionRequestString: String`, and the return type changed to `String`.
- New methods added: `createJWTPresentationSubmission`, `createAnoncredsPresentationSubmission`, and `getSchema`.
- `createPresentationDefinitionRequest` now returns a `String`.

OutOfBandInvitation
- New constructor parameters: `attachments`, `createdTime`, and `expiresTime`.

Module Renaming
- `AtalaPrismSDK` renamed to `EdgeAgentSDK`.
- Package name changed from `io.iohk.atala.prism.walletsdk` to `org.hyperledger.identus.walletsdk`.
- `publishedMavenId` changed from `io.iohk.atala.prism.walletsdk` to `org.hyperledger.identus`.
- Namespace changed from `org.hyperledger.identus.walletsdk` to `org.hyperledger.identus`.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
