### PR TITLE
chore: disable artifact sign for local builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -193,14 +193,16 @@ subprojects {
                             url.set("https://github.com/hyperledger/identus-edge-agent-sdk-kmp")
                         }
                     }
-                    signing {
-                        useInMemoryPgpKeys(
-                            project.findProperty("signing.signingSecretKey") as String?
-                                ?: System.getenv("OSSRH_GPG_SECRET_KEY"),
-                            project.findProperty("signing.signingSecretKeyPassword") as String?
-                                ?: System.getenv("OSSRH_GPG_SECRET_KEY_PASSWORD")
-                        )
-                        sign(this@withType)
+                    if (System.getenv().containsKey("OSSRH_GPG_SECRET_KEY")) {
+                        signing {
+                            useInMemoryPgpKeys(
+                                project.findProperty("signing.signingSecretKey") as String?
+                                    ?: System.getenv("OSSRH_GPG_SECRET_KEY"),
+                                project.findProperty("signing.signingSecretKeyPassword") as String?
+                                    ?: System.getenv("OSSRH_GPG_SECRET_KEY_PASSWORD")
+                            )
+                            sign(this@withType)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description: 
Removes the sign when publishing to maven local

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
