### PR TITLE
fix: release 4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -188,8 +188,8 @@ subprojects {
                             }
                         }
                         scm {
-                            connection.set("scm:git:git://hyperledger/identus-edge-agent-sdk-kmp.git")
-                            developerConnection.set("scm:git:ssh://hyperledger/identus-edge-agent-sdk-kmp.git")
+                            connection.set("scm:git:git:/git@github.com/hyperledger/identus-edge-agent-sdk-kmp.git")
+                            developerConnection.set("scm:git:ssh:/git@github.com/hyperledger/identus-edge-agent-sdk-kmp.git")
                             url.set("https://github.com/hyperledger/identus-edge-agent-sdk-kmp")
                         }
                     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 3.0.0
+version = 4.0.0
 org.gradle.jvmargs = -Xmx3072M -Dkotlin.daemon.jvm.options="-Xmx3072M"
 kotlin.code.style = official
 android.useAndroidX = true


### PR DESCRIPTION
Signed-off-by: Cristian G <cristian.castro@iohk.io>

### Description: 
Release flow fails: 
`Failed to remove private key due to: The process '/usr/bin/gpg' failed with exit code 2`.
This error was seen on apollo release and resolved. Used the same commit to update the release flow for kmp but found something that was not included correctly.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-kmm/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
